### PR TITLE
optionally add type safety for "source"

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,8 @@ export type EntityIdGetter<T> = (string & keyof T) | ((element: T) => string);
 
 export type EntityLookupFunction<T = any> = (keys: string[]) => Promise<T[]> | T[];
 
-export type AggregationConfiguration = {
-    [idPath: string]: SingleAggregationOpts;
+export type AggregationConfiguration<TLookUpSource=string> = {
+    [idPath: string]: SingleAggregationOpts<TLookUpSource>;
 };
 
 export type ToKeyModeOpts = {
@@ -20,8 +20,8 @@ export type ToKeyModeOpts = {
     omitNull?: boolean;
 }
 
-export type SingleAggregationOpts = {
-    source: string;
+export type SingleAggregationOpts<TLookUpSource> = {
+    source: string & <TLookUpSource>;
     to?: ToKeyModeOpts;
     removeIdKey?: boolean;
     transform?: (element: any) => any;


### PR DESCRIPTION
```typescript
export enum LookUpSources {
    user = 'user',
    client = 'client',
    project = 'project',
    task = 'task',
    userByEmail = 'user',
    expenseField = 'expense_field',
    expenseCategory = 'expense_category',
    projectCostCenter = 'project_cost_center',
    usersCostCenter = 'users_cost_center',
}
compileAggregator(opts: AggregationConfiguration<LookUpSources>) {};
```